### PR TITLE
Update package versions in project files

### DIFF
--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -32,8 +32,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Api" Version="2024.12.24.18" />
-		<PackageReference Include="G4.Plugins" Version="2025.1.14.13" />
+		<PackageReference Include="G4.Api" Version="2025.1.16.19" />
+		<PackageReference Include="G4.Plugins" Version="2025.1.16.14" />
 		<PackageReference Include="G4.Converters" Version="2024.11.14.75" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.10" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/src/G4.Plugins.Common/G4.Plugins.Common.csproj
+++ b/src/G4.Plugins.Common/G4.Plugins.Common.csproj
@@ -26,7 +26,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Extensions" Version="2024.11.14.75" />
-		<PackageReference Include="G4.Plugins" Version="2025.1.14.13" />
+		<PackageReference Include="G4.Plugins" Version="2025.1.16.14" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -33,11 +33,11 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction.Logging" Version="2024.12.23.5" />
-		<PackageReference Include="G4.Api" Version="2024.12.24.18" />
-		<PackageReference Include="G4.Plugins" Version="2025.1.14.13" />
+		<PackageReference Include="G4.Api" Version="2025.1.16.19" />
+		<PackageReference Include="G4.Plugins" Version="2025.1.16.14" />
 		<PackageReference Include="G4.Extensions" Version="2024.11.14.75" />
-		<PackageReference Include="G4.Models" Version="2025.1.14.13" />
-		<PackageReference Include="G4.Settings" Version="2025.1.14.13" />
+		<PackageReference Include="G4.Models" Version="2025.1.16.14" />
+		<PackageReference Include="G4.Settings" Version="2025.1.16.14" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.10" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.7.1" />


### PR DESCRIPTION
Updated package references in the following project files:
- `G4.IntegrationTests.csproj`: Updated `G4.Api` to `2025.1.16.19` and `G4.Plugins` to `2025.1.16.14`.
- `G4.Plugins.Common.csproj`: Updated `G4.Plugins` to `2025.1.16.14`.
- `G4.UnitTests.csproj`: Updated `G4.Api` to `2025.1.16.19`, `G4.Plugins` to `2025.1.16.14`, `G4.Models` to `2025.1.16.14`, and `G4.Settings` to `2025.1.16.14`.