### PR TITLE
Refactor conditional logic from "Condition" to "Switch"

### DIFF
--- a/src/G4.Plugins.Common/Actions.Manifests/SetCondition.json
+++ b/src/G4.Plugins.Common/Actions.Manifests/SetCondition.json
@@ -9,14 +9,14 @@
 	"context": {
 		"integration": {
 			"sequentialWorkflow": {
-				"$type": "Condition",
+				"$type": "Switch",
 				"branches": [
 					"false",
 					"true"
 				],
 				"componentType": "switch",
 				"iconProvider": "if",
-				"model": "ConditionRuleModel"
+				"model": "SwitchRuleModel"
 			}
 		}
 	},
@@ -56,17 +56,21 @@
 				"This configuration evaluates a condition and executes sub-actions if the condition is met."
 			],
 			"rule": {
+				"$type": "Switch",
 				"argument": "{{$ --Condition:ElementText --Operator:Equal --Expected:Hello World}}",
+				"branches": {
+					"true": [
+						{
+							"$type": "Action",
+							"locator": "CssSelector",
+							"onElement": "#continueButton",
+							"pluginName": "Click"
+						}
+					]
+				},
 				"locator": "CssSelector",
 				"onElement": "#greeting",
-				"pluginName": "SetCondition",
-				"rules": [
-					{
-						"locator": "CssSelector",
-						"onElement": "#continueButton",
-						"pluginName": "Click"
-					}
-				]
+				"pluginName": "SetCondition"
 			}
 		},
 		{
@@ -74,32 +78,40 @@
 				"This configuration checks if an alert exists and executes sub-actions if no alert is present."
 			],
 			"rule": {
+				"$type": "Switch",
 				"argument": "{{$ --Condition:AlertExists}}",
-				"pluginName": "SetCondition",
-				"rules": [
-					{
-						"argument": "Test Input",
-						"locator": "CssSelector",
-						"onElement": "#inputField",
-						"pluginName": "SendKeys"
-					}
-				]
+				"branches": {
+					"true": [
+						{
+							"$type": "Action",
+							"argument": "Test Input",
+							"locator": "CssSelector",
+							"onElement": "#inputField",
+							"pluginName": "SendKeys"
+						}
+					]
+				},
+				"pluginName": "SetCondition"
 			}
 		},
 		{
 			"description": [
-				"This configuration checks if the page URL matches a specific pattern and executes sub-actions accordingly."
+				"This configuration checks if the page URL does not matche a specific pattern and executes sub-actions accordingly."
 			],
 			"rule": {
-				"argument": "{{$ --Condition:PageUrl --Operator:Match --Expected:https://example.com/*}}",
-				"pluginName": "SetCondition",
-				"rules": [
-					{
-						"locator": "CssSelector",
-						"onElement": "#nextPageButton",
-						"pluginName": "Click"
-					}
-				]
+				"$type": "Switch",
+				"argument": "{{$ --Condition:PageUrl --Operator:NotMatch --Expected:https://example.com/*}}",
+				"branches": {
+					"false": [
+						{
+							"$type": "Action",
+							"locator": "CssSelector",
+							"onElement": "#nextPageButton",
+							"pluginName": "Click"
+						}
+					]
+				},
+				"pluginName": "SetCondition"
 			}
 		}
 	],
@@ -173,8 +185,8 @@
 			"description": [
 				"Define a sequence of actions or instructions to be executed if the condition is met."
 			],
-			"name": "Rules",
-			"type": "Array"
+			"name": "Branches",
+			"type": "Object"
 		}
 	],
 	"protocol": {


### PR DESCRIPTION
Updated SetCondition.json to replace "Condition" with "Switch" for defining conditional logic. Changed `$type` from "Condition" to "Switch" and model from "ConditionRuleModel" to "SwitchRuleModel". Replaced "rules" with "branches" for defining actions based on condition outcomes. Updated descriptions to reflect new logic, including URL pattern checks. Modified configuration structure to use "Object" type for "Branches" instead of "Array" type for "Rules". Updated examples to use the new "Switch" structure for conditions like element text, alert existence, and page URL matching.