### PR TITLE
Update package versions across multiple projects

### DIFF
--- a/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
+++ b/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
@@ -17,7 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction" Version="2024.11.14.75" />
-		<PackageReference Include="G4.Converters" Version="2025.1.24.18" />
+		<PackageReference Include="G4.Converters" Version="2025.2.3.19" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -32,9 +32,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Api" Version="2025.1.21.23" />
-		<PackageReference Include="G4.Plugins" Version="2025.1.24.18" />
-		<PackageReference Include="G4.Converters" Version="2025.1.24.18" />
+		<PackageReference Include="G4.Api" Version="2025.1.24.24" />
+		<PackageReference Include="G4.Plugins" Version="2025.2.3.19" />
+		<PackageReference Include="G4.Converters" Version="2025.2.3.19" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.10" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />

--- a/src/G4.ManifestValidator/G4.ManifestValidator.csproj
+++ b/src/G4.ManifestValidator/G4.ManifestValidator.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Attributes" Version="2025.1.24.18" />
+		<PackageReference Include="G4.Attributes" Version="2025.2.3.19" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.Plugins.Common/G4.Plugins.Common.csproj
+++ b/src/G4.Plugins.Common/G4.Plugins.Common.csproj
@@ -25,9 +25,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2025.1.24.18" />
-		<PackageReference Include="G4.Extensions" Version="2025.1.24.18" />
-		<PackageReference Include="G4.Plugins" Version="2025.1.24.18" />
+		<PackageReference Include="G4.Converters" Version="2025.2.3.19" />
+		<PackageReference Include="G4.Extensions" Version="2025.2.3.19" />
+		<PackageReference Include="G4.Plugins" Version="2025.2.3.19" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
+++ b/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="G4.Converters" Version="2025.1.24.18" />
+	  <PackageReference Include="G4.Converters" Version="2025.2.3.19" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -32,13 +32,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Abstraction.Logging" Version="2024.12.23.5" />
-		<PackageReference Include="G4.Api" Version="2025.1.21.23" />
-		<PackageReference Include="G4.Converters" Version="2025.1.24.18" />
-		<PackageReference Include="G4.Plugins" Version="2025.1.24.18" />
-		<PackageReference Include="G4.Extensions" Version="2025.1.24.18" />
-		<PackageReference Include="G4.Models" Version="2025.1.24.18" />
-		<PackageReference Include="G4.Settings" Version="2025.1.24.18" />
+		<PackageReference Include="G4.Abstraction.Logging" Version="2025.2.3.6" />
+		<PackageReference Include="G4.Api" Version="2025.1.24.24" />
+		<PackageReference Include="G4.Converters" Version="2025.2.3.19" />
+		<PackageReference Include="G4.Plugins" Version="2025.2.3.19" />
+		<PackageReference Include="G4.Extensions" Version="2025.2.3.19" />
+		<PackageReference Include="G4.Models" Version="2025.2.3.19" />
+		<PackageReference Include="G4.Settings" Version="2025.2.3.19" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.10" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.7.2" />


### PR DESCRIPTION
Updated various .csproj files to use new versions of several packages:
- `G4.DocumentsGenerator.csproj`: `G4.Converters` to `2025.2.3.19`
- `G4.IntegrationTests.csproj`: `G4.Api` to `2025.1.24.24`, `G4.Plugins` to `2025.2.3.19`, `G4.Converters` to `2025.2.3.19`
- `G4.ManifestValidator.csproj`: `G4.Attributes` to `2025.2.3.19`
- `G4.Plugins.Common.csproj`: `G4.Converters`, `G4.Extensions`, `G4.Plugins` to `2025.2.3.19`
- `G4.Plugins.Ui.csproj`: `G4.Converters` to `2025.2.3.19`
- `G4.UnitTests.csproj`: `G4.Abstraction.Logging` to `2025.2.3.6`, `G4.Api` to `2025.1.24.24`, `G4.Converters`, `G4.Plugins`, `G4.Extensions`, `G4.Models`, `G4.Settings` to `2025.2.3.19`