### PR TITLE
Update package versions across multiple projects

### DIFF
--- a/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
+++ b/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>		<PackageReference Include="G4.Abstraction.Cli" Version="2025.2.7.15" />
-		<PackageReference Include="G4.Converters" Version="2025.2.8.30" />
+		<PackageReference Include="G4.Converters" Version="2025.2.13.32" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -32,13 +32,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Api" Version="2025.2.7.27" />
-		<PackageReference Include="G4.Plugins" Version="2025.2.8.30" />
-		<PackageReference Include="G4.Converters" Version="2025.2.8.30" />
+		<PackageReference Include="G4.Api" Version="2025.2.9.28" />
+		<PackageReference Include="G4.Plugins" Version="2025.2.13.32" />
+		<PackageReference Include="G4.Converters" Version="2025.2.13.32" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.10" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
 		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/G4.ManifestValidator/G4.ManifestValidator.csproj
+++ b/src/G4.ManifestValidator/G4.ManifestValidator.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Attributes" Version="2025.2.8.30" />
+		<PackageReference Include="G4.Attributes" Version="2025.2.13.32" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.Plugins.Common/G4.Plugins.Common.csproj
+++ b/src/G4.Plugins.Common/G4.Plugins.Common.csproj
@@ -25,9 +25,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2025.2.8.30" />
-		<PackageReference Include="G4.Extensions" Version="2025.2.8.30" />
-		<PackageReference Include="G4.Plugins" Version="2025.2.8.30" />
+		<PackageReference Include="G4.Converters" Version="2025.2.13.32" />
+		<PackageReference Include="G4.Extensions" Version="2025.2.13.32" />
+		<PackageReference Include="G4.Plugins" Version="2025.2.13.32" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
+++ b/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2025.2.8.30" />
+		<PackageReference Include="G4.Converters" Version="2025.2.13.32" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -33,16 +33,16 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction.Logging" Version="2025.2.7.15" />
-		<PackageReference Include="G4.Api" Version="2025.2.7.27" />
-		<PackageReference Include="G4.Converters" Version="2025.2.8.30" />
-		<PackageReference Include="G4.Plugins" Version="2025.2.8.30" />
-		<PackageReference Include="G4.Extensions" Version="2025.2.8.30" />
-		<PackageReference Include="G4.Models" Version="2025.2.8.30" />
-		<PackageReference Include="G4.Settings" Version="2025.2.8.30" />
+		<PackageReference Include="G4.Api" Version="2025.2.9.28" />
+		<PackageReference Include="G4.Converters" Version="2025.2.13.32" />
+		<PackageReference Include="G4.Plugins" Version="2025.2.13.32" />
+		<PackageReference Include="G4.Extensions" Version="2025.2.13.32" />
+		<PackageReference Include="G4.Models" Version="2025.2.13.32" />
+		<PackageReference Include="G4.Settings" Version="2025.2.13.32" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.10" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
 		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updated various package versions in multiple project files:
- G4.DocumentsGenerator.csproj: G4.Converters to 2025.2.13.32
- G4.IntegrationTests.csproj: G4.Api, G4.Plugins, G4.Converters, Microsoft.NET.Test.Sdk, MSTest.TestAdapter, MSTest.TestFramework
- G4.ManifestValidator.csproj: G4.Attributes to 2025.2.13.32
- G4.Plugins.Common.csproj: G4.Converters, G4.Extensions, G4.Plugins
- G4.Plugins.Ui.csproj: G4.Converters to 2025.2.13.32
- G4.UnitTests.csproj: G4.Api, G4.Converters, G4.Plugins, G4.Extensions, G4.Models, G4.Settings, Microsoft.NET.Test.Sdk, MSTest.TestAdapter, MSTest.TestFramework