### PR TITLE
Update NuGet packages and clean up project references

### DIFF
--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -36,14 +36,14 @@
 		<PackageReference Include="G4.Plugins" Version="2025.5.19.38" />
 		<PackageReference Include="G4.Converters" Version="2025.5.19.38" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.10" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
 		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Plugins.Common/G4.Plugins.Common.csproj
+++ b/src/G4.Plugins.Common/G4.Plugins.Common.csproj
@@ -28,17 +28,11 @@
 		<PackageReference Include="G4.Converters" Version="2025.5.19.38" />
 		<PackageReference Include="G4.Extensions" Version="2025.5.19.38" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.16" />
-		<!--
 		<PackageReference Include="G4.Plugins" Version="2025.5.19.38" />
-		-->
 	</ItemGroup>
 
 	<ItemGroup>
 		<EmbeddedResource Include="*.Manifests\**\*.*" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <ProjectReference Include="..\..\..\g4-engine\src\G4.Plugins\G4.Plugins.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -40,14 +40,14 @@
 		<PackageReference Include="G4.Models" Version="2025.5.19.38" />
 		<PackageReference Include="G4.Settings" Version="2025.5.19.38" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.10" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
 		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
 		<PackageReference Include="System.Runtime" Version="4.3.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
Updated `Microsoft.NET.Test.Sdk`, `MSTest.TestAdapter`, and `MSTest.TestFramework` to newer versions in
`G4.IntegrationTests.csproj` and `G4.UnitTests.csproj`. Updated `Swashbuckle.AspNetCore` version in both projects. Removed commented-out and unnecessary project references in `G4.Plugins.Common.csproj` to enhance compatibility and functionality.