### PR TITLE
Update iconProvider in JSON files

### DIFF
--- a/src/G4.Plugins.Common/Transformers.Manifests/ClearLines.json
+++ b/src/G4.Plugins.Common/Transformers.Manifests/ClearLines.json
@@ -14,7 +14,7 @@
 			"sequentialWorkflow": {
 				"$type": "Transformer",
 				"componentType": "task",
-				"iconProvider": "arrows-turn-to-dots",
+				"iconProvider": "text-height",
 				"model": "TransformerRuleModel"
 			}
 		}

--- a/src/G4.Plugins.Common/Transformers.Manifests/ClearTabs.json
+++ b/src/G4.Plugins.Common/Transformers.Manifests/ClearTabs.json
@@ -14,7 +14,7 @@
 			"sequentialWorkflow": {
 				"$type": "Transformer",
 				"componentType": "task",
-				"iconProvider": "arrows-turn-to-dots",
+				"iconProvider": "text-height",
 				"model": "TransformerRuleModel"
 			}
 		}

--- a/src/G4.Plugins.Common/Transformers.Manifests/Trim.json
+++ b/src/G4.Plugins.Common/Transformers.Manifests/Trim.json
@@ -11,7 +11,7 @@
 			"sequentialWorkflow": {
 				"$type": "Transformer",
 				"componentType": "task",
-				"iconProvider": "arrows-turn-to-dots",
+				"iconProvider": "text-height",
 				"model": "TransformerRuleModel"
 			}
 		}

--- a/src/G4.Plugins.Common/Transformers.Manifests/TrimEnd.json
+++ b/src/G4.Plugins.Common/Transformers.Manifests/TrimEnd.json
@@ -11,7 +11,7 @@
 			"sequentialWorkflow": {
 				"$type": "Transformer",
 				"componentType": "task",
-				"iconProvider": "arrows-turn-to-dots",
+				"iconProvider": "text-height",
 				"model": "TransformerRuleModel"
 			}
 		}

--- a/src/G4.Plugins.Common/Transformers.Manifests/TrimStart.json
+++ b/src/G4.Plugins.Common/Transformers.Manifests/TrimStart.json
@@ -11,7 +11,7 @@
 			"sequentialWorkflow": {
 				"$type": "Transformer",
 				"componentType": "task",
-				"iconProvider": "arrows-turn-to-dots",
+				"iconProvider": "text-height",
 				"model": "TransformerRuleModel"
 			}
 		}


### PR DESCRIPTION
Modified the `iconProvider` property in multiple JSON files (`ClearLines.json`, `ClearTabs.json`, `Trim.json`, `TrimEnd.json`, `TrimStart.json`) from `"arrows-turn-to-dots"` to `"text-height"`. This change updates the visual representation for the `Transformer` component type within the `sequentialWorkflow` context.