### PR TITLE
Update G4.* and Swashbuckle NuGet package versions

### DIFF
--- a/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
+++ b/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
@@ -17,7 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction.Cli" Version="2026.4.29.20" />
-		<PackageReference Include="G4.Converters" Version="2026.6.15.66" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
 	</ItemGroup>
 

--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -32,9 +32,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Api" Version="2026.4.30.45" />
-		<PackageReference Include="G4.Plugins" Version="2026.6.15.66" />
-		<PackageReference Include="G4.Converters" Version="2026.6.15.66" />
+		<PackageReference Include="G4.Api" Version="2026.6.16.46" />
+		<PackageReference Include="G4.Plugins" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.9" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
@@ -43,7 +43,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.ManifestValidator/G4.ManifestValidator.csproj
+++ b/src/G4.ManifestValidator/G4.ManifestValidator.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Attributes" Version="2026.6.15.66" />
+		<PackageReference Include="G4.Attributes" Version="2026.6.23.68" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.Plugins.Common/G4.Plugins.Common.csproj
+++ b/src/G4.Plugins.Common/G4.Plugins.Common.csproj
@@ -25,10 +25,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.6.15.66" />
-		<PackageReference Include="G4.Extensions" Version="2026.6.15.66" />
-		<PackageReference Include="G4.Plugins" Version="2026.6.15.66" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Extensions" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Plugins" Version="2026.6.23.68" />
 		<PackageReference Include="PdfPig" Version="0.1.14" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
 	</ItemGroup>

--- a/src/G4.Plugins.Google/G4.Plugins.Google.csproj
+++ b/src/G4.Plugins.Google/G4.Plugins.Google.csproj
@@ -25,8 +25,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.6.15.66" />
-		<PackageReference Include="G4.Extensions" Version="2026.6.15.66" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Extensions" Version="2026.6.23.68" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
+++ b/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.6.15.66" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -33,12 +33,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction.Logging" Version="2026.4.29.20" />
-		<PackageReference Include="G4.Api" Version="2026.4.30.45" />
-		<PackageReference Include="G4.Converters" Version="2026.6.15.66" />
-		<PackageReference Include="G4.Plugins" Version="2026.6.15.66" />
-		<PackageReference Include="G4.Extensions" Version="2026.6.15.66" />
-		<PackageReference Include="G4.Models" Version="2026.6.15.66" />
-		<PackageReference Include="G4.Settings" Version="2026.6.15.66" />
+		<PackageReference Include="G4.Api" Version="2026.6.16.46" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Plugins" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Extensions" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Models" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Settings" Version="2026.6.23.68" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.9" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
@@ -47,7 +47,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Upgraded G4.* package references to the latest 2026.6.x versions across all projects. Also updated Swashbuckle.AspNetCore to 10.2.3 in test projects. No other code or configuration changes were made.