### PR TITLE
Update G4 package versions and improve test reliability

### DIFF
--- a/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
+++ b/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
@@ -17,7 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction.Cli" Version="2026.4.29.20" />
-		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
 	</ItemGroup>
 

--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -33,10 +33,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Api" Version="2026.6.16.46" />
-		<PackageReference Include="G4.Plugins" Version="2026.6.23.68" />
-		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Plugins" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.9" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
 		<PackageReference Include="coverlet.collector" Version="10.0.1">

--- a/src/G4.ManifestValidator/G4.ManifestValidator.csproj
+++ b/src/G4.ManifestValidator/G4.ManifestValidator.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Attributes" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Attributes" Version="2026.6.23.69" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.Plugins.Common/G4.Plugins.Common.csproj
+++ b/src/G4.Plugins.Common/G4.Plugins.Common.csproj
@@ -25,9 +25,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
-		<PackageReference Include="G4.Extensions" Version="2026.6.23.68" />
-		<PackageReference Include="G4.Plugins" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Extensions" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Plugins" Version="2026.6.23.69" />
 		<PackageReference Include="PdfPig" Version="0.1.14" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
 	</ItemGroup>

--- a/src/G4.Plugins.Google/G4.Plugins.Google.csproj
+++ b/src/G4.Plugins.Google/G4.Plugins.Google.csproj
@@ -25,8 +25,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
-		<PackageReference Include="G4.Extensions" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Extensions" Version="2026.6.23.69" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
+++ b/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.UnitTests/Framework/TestBase.cs
+++ b/src/G4.UnitTests/Framework/TestBase.cs
@@ -809,10 +809,10 @@ namespace G4.UnitTests.Framework
             }
 
             // Assert that the plugin has a description
-            Assert.IsTrue(attribute.Description.Any(), "Plugin must have a description.");
+            Assert.IsNotEmpty(attribute.Description, "Plugin must have a description.");
 
             // Assert that the plugin has a summary
-            Assert.IsTrue(attribute.Summary.Any(), "Plugin must have a summary.");
+            Assert.IsNotEmpty(attribute.Summary, "Plugin must have a summary.");
 
             // If a custom plugin name is provided, check if it matches the plugin's key
             if (pluginName != null)
@@ -821,7 +821,7 @@ namespace G4.UnitTests.Framework
             }
 
             // Assert that the plugin has at least one example
-            Assert.IsTrue(attribute.Examples.Any(), "Plugin must have at least one example.");
+            Assert.IsNotEmpty(attribute.Examples, "Plugin must have at least one example.");
 
             // Assert that all examples have at least one action rule
             Assert.IsTrue(attribute.Examples.All(i => i.Rule != null), "Plugin example must have at least one action rule.");
@@ -848,7 +848,7 @@ namespace G4.UnitTests.Framework
             Assert.AreNotEqual(notExpected: default, actual: action, message: "Plugin was not generated correctly.");
 
             // Assert that plugin types have been loaded into the cache manager
-            Assert.AreNotEqual(notExpected: 0, actual: CacheManager.Types.Count, message: "Plugin types were not loaded.");
+            Assert.IsNotEmpty(CacheManager.Types, "Plugin types were not loaded.");
 
             // If the action is derived from PluginBase, assert that its WebDriver property is not null
             if (action is PluginBase)
@@ -963,7 +963,7 @@ namespace G4.UnitTests.Framework
                 }
 
                 // Filter out null parameters and return the matched parameters as an array
-                return parametersResult.Where(i => i != null).ToArray();
+                return [.. parametersResult.Where(i => i != null)];
             }
 
             // Get the constructor with the most parameters for the specified plugin type

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -34,13 +34,13 @@
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction.Logging" Version="2026.4.29.20" />
 		<PackageReference Include="G4.Api" Version="2026.6.16.46" />
-		<PackageReference Include="G4.Converters" Version="2026.6.23.68" />
-		<PackageReference Include="G4.Plugins" Version="2026.6.23.68" />
-		<PackageReference Include="G4.Extensions" Version="2026.6.23.68" />
-		<PackageReference Include="G4.Models" Version="2026.6.23.68" />
-		<PackageReference Include="G4.Settings" Version="2026.6.23.68" />
+		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Plugins" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Extensions" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Models" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Settings" Version="2026.6.23.69" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.9" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
 		<PackageReference Include="coverlet.collector" Version="10.0.1">

--- a/src/G4.UnitTests/Plugins.Common/InvokeForEachLoopTests.cs
+++ b/src/G4.UnitTests/Plugins.Common/InvokeForEachLoopTests.cs
@@ -1,6 +1,7 @@
 ﻿using G4.Extensions;
 using G4.Models;
 using G4.Plugins.Common.Actions;
+using G4.UnitTests.Attributes;
 using G4.UnitTests.Extensions;
 using G4.UnitTests.Framework;
 
@@ -43,7 +44,7 @@ namespace G4.UnitTests.Plugins.Common
                 expectedPerformancePoints: 3);
         }
 
-        [TestMethod(DisplayName = "Verify that the InvokeForEachLoop plugin performs nested " +
+        [RetryableTestMethod(5, DisplayName = "Verify that the InvokeForEachLoop plugin performs nested " +
             "loops correctly and awards the expected performance points.")]
         public void InvokeForEachLoopWithNestedLoopPositiveTest()
         {

--- a/src/G4.UnitTests/Plugins.Common/OperatorMatchTests.cs
+++ b/src/G4.UnitTests/Plugins.Common/OperatorMatchTests.cs
@@ -1,5 +1,6 @@
 ﻿using G4.Models;
 using G4.Plugins.Common.Operators;
+using G4.UnitTests.Attributes;
 using G4.UnitTests.Extensions;
 using G4.UnitTests.Framework;
 
@@ -64,7 +65,7 @@ namespace G4.UnitTests.Plugins.Common
             Assert.IsFalse(session.ResponseData.Extractions.GetEvaluation());
         }
 
-        [TestMethod(DisplayName = "Verify that the MatchOperator plugin evaluates correctly " +
+        [RetryableTestMethod(5, DisplayName = "Verify that the MatchOperator plugin evaluates correctly " +
             "in positive scenarios.")]
         #region *** Data Set ***
         [DataRow(Stubs.RuleJsonAttributeOperator, "random", "Match", @"^mock attribute value \\d+$", "ElementAttribute", ".//positive")]


### PR DESCRIPTION
Updated G4-related NuGet packages to 2026.6.23.69 and Microsoft.NET.Test.Sdk to 18.7.0. Refactored assertions in TestBase.cs to use Assert.IsNotEmpty and modernized parameter filtering. Replaced [TestMethod] with [RetryableTestMethod] in key tests for improved reliability and imported necessary attributes.