### PR TITLE
Update G4 and MSTest package versions across projects

### DIFF
--- a/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
+++ b/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
@@ -17,7 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction.Cli" Version="2026.4.29.20" />
-		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Converters" Version="2026.7.11.70" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
 	</ItemGroup>
 

--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -33,12 +33,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Api" Version="2026.6.24.47" />
-		<PackageReference Include="G4.Plugins" Version="2026.6.23.69" />
-		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Plugins" Version="2026.7.11.70" />
+		<PackageReference Include="G4.Converters" Version="2026.7.11.70" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.9" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
 		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/G4.ManifestValidator/G4.ManifestValidator.csproj
+++ b/src/G4.ManifestValidator/G4.ManifestValidator.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Attributes" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Attributes" Version="2026.7.11.70" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.Plugins.Common/G4.Plugins.Common.csproj
+++ b/src/G4.Plugins.Common/G4.Plugins.Common.csproj
@@ -25,9 +25,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
-		<PackageReference Include="G4.Extensions" Version="2026.6.23.69" />
-		<PackageReference Include="G4.Plugins" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Converters" Version="2026.7.11.70" />
+		<PackageReference Include="G4.Extensions" Version="2026.7.11.70" />
+		<PackageReference Include="G4.Plugins" Version="2026.7.11.70" />
 		<PackageReference Include="PdfPig" Version="0.1.15" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
 	</ItemGroup>

--- a/src/G4.Plugins.Google/G4.Plugins.Google.csproj
+++ b/src/G4.Plugins.Google/G4.Plugins.Google.csproj
@@ -25,8 +25,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
-		<PackageReference Include="G4.Extensions" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Converters" Version="2026.7.11.70" />
+		<PackageReference Include="G4.Extensions" Version="2026.7.11.70" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
+++ b/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Converters" Version="2026.7.11.70" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -34,15 +34,15 @@
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction.Logging" Version="2026.4.29.20" />
 		<PackageReference Include="G4.Api" Version="2026.6.24.47" />
-		<PackageReference Include="G4.Converters" Version="2026.6.23.69" />
-		<PackageReference Include="G4.Plugins" Version="2026.6.23.69" />
-		<PackageReference Include="G4.Extensions" Version="2026.6.23.69" />
-		<PackageReference Include="G4.Models" Version="2026.6.23.69" />
-		<PackageReference Include="G4.Settings" Version="2026.6.23.69" />
+		<PackageReference Include="G4.Converters" Version="2026.7.11.70" />
+		<PackageReference Include="G4.Plugins" Version="2026.7.11.70" />
+		<PackageReference Include="G4.Extensions" Version="2026.7.11.70" />
+		<PackageReference Include="G4.Models" Version="2026.7.11.70" />
+		<PackageReference Include="G4.Settings" Version="2026.7.11.70" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.9" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
 		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Updated G4-related NuGet packages to 2026.7.11.70 in all relevant projects. Upgraded MSTest.TestAdapter and MSTest.TestFramework to 4.3.0 in test projects. This ensures consistency and access to the latest features and fixes.