### PR TITLE
Update NuGet package versions in .csproj files

### DIFF
--- a/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
+++ b/src/G4.DocumentsGenerator/G4.DocumentsGenerator.csproj
@@ -17,8 +17,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction.Cli" Version="2026.4.29.20" />
-		<PackageReference Include="G4.Converters" Version="2026.8.10.73" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+		<PackageReference Include="G4.Converters" Version="2026.8.11.74" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.IntegrationTests/G4.IntegrationTests.csproj
+++ b/src/G4.IntegrationTests/G4.IntegrationTests.csproj
@@ -32,10 +32,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Api" Version="2026.7.31.52" />
-		<PackageReference Include="G4.Plugins" Version="2026.8.10.73" />
-		<PackageReference Include="G4.Converters" Version="2026.8.10.73" />
-		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.10" PrivateAssets="all" />
+		<PackageReference Include="G4.Api" Version="2026.8.11.53" />
+		<PackageReference Include="G4.Plugins" Version="2026.8.11.74" />
+		<PackageReference Include="G4.Converters" Version="2026.8.11.74" />
+		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.11" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.3.3" />

--- a/src/G4.ManifestValidator/G4.ManifestValidator.csproj
+++ b/src/G4.ManifestValidator/G4.ManifestValidator.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Attributes" Version="2026.8.10.73" />
+		<PackageReference Include="G4.Attributes" Version="2026.8.11.74" />
 	</ItemGroup>
 
 </Project>

--- a/src/G4.Plugins.Common/G4.Plugins.Common.csproj
+++ b/src/G4.Plugins.Common/G4.Plugins.Common.csproj
@@ -25,11 +25,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.8.10.73" />
-		<PackageReference Include="G4.Extensions" Version="2026.8.10.73" />
-		<PackageReference Include="G4.Plugins" Version="2026.8.10.73" />
+		<PackageReference Include="G4.Converters" Version="2026.8.11.74" />
+		<PackageReference Include="G4.Extensions" Version="2026.8.11.74" />
+		<PackageReference Include="G4.Plugins" Version="2026.8.11.74" />
 		<PackageReference Include="PdfPig" Version="0.1.15" />
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Plugins.Google/G4.Plugins.Google.csproj
+++ b/src/G4.Plugins.Google/G4.Plugins.Google.csproj
@@ -25,8 +25,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.8.10.73" />
-		<PackageReference Include="G4.Extensions" Version="2026.8.10.73" />
+		<PackageReference Include="G4.Converters" Version="2026.8.11.74" />
+		<PackageReference Include="G4.Extensions" Version="2026.8.11.74" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
+++ b/src/G4.Plugins.Ui/G4.Plugins.Ui.csproj
@@ -33,7 +33,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="G4.Converters" Version="2026.8.10.73" />
+		<PackageReference Include="G4.Converters" Version="2026.8.11.74" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/G4.UnitTests/G4.UnitTests.csproj
+++ b/src/G4.UnitTests/G4.UnitTests.csproj
@@ -33,13 +33,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="G4.Abstraction.Logging" Version="2026.4.29.20" />
-		<PackageReference Include="G4.Api" Version="2026.7.31.52" />
-		<PackageReference Include="G4.Converters" Version="2026.8.10.73" />
-		<PackageReference Include="G4.Plugins" Version="2026.8.10.73" />
-		<PackageReference Include="G4.Extensions" Version="2026.8.10.73" />
-		<PackageReference Include="G4.Models" Version="2026.8.10.73" />
-		<PackageReference Include="G4.Settings" Version="2026.8.10.73" />
-		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.10" PrivateAssets="all" />
+		<PackageReference Include="G4.Api" Version="2026.8.11.53" />
+		<PackageReference Include="G4.Converters" Version="2026.8.11.74" />
+		<PackageReference Include="G4.Plugins" Version="2026.8.11.74" />
+		<PackageReference Include="G4.Extensions" Version="2026.8.11.74" />
+		<PackageReference Include="G4.Models" Version="2026.8.11.74" />
+		<PackageReference Include="G4.Settings" Version="2026.8.11.74" />
+		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.11" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
 		<PackageReference Include="MSTest.TestFramework" Version="4.3.3" />


### PR DESCRIPTION
Updated several NuGet package references to newer versions across multiple .csproj files, including G4.Converters, G4.Api, G4.Plugins, G4.Extensions, G4.Models, G4.Settings, G4.Attributes, System.Security.Cryptography.Xml, and Microsoft.AspNetCore.MiddlewareAnalysis (10.0.10 → 10.0.11). No other code or configuration changes were made.